### PR TITLE
Add transpose functionality to TabDisplay.

### DIFF
--- a/frontend/src/components/TabDisplay.tsx
+++ b/frontend/src/components/TabDisplay.tsx
@@ -11,13 +11,13 @@ function formatTab(tab, toneSteps) {
       break;
     }
   }
-  const newArray = tab.slice(tabStartIndex, tab.length);
-  const capoValueString = capoArray[0] || [];
-  const transposeValueString =
+  const trimmedTab = tab.slice(tabStartIndex, tab.length);
+  const capoDisplay = capoArray[0] || [];
+  const transposeDisplay =
     toneSteps != 0 ? "transposed " + toneSteps + " steps" : "";
-  const pitchBendString = capoValueString + " " + transposeValueString;
-  const fixedTabArray = [pitchBendString, ...newArray];
-  return fixedTabArray;
+  const capoAndTranspositionDisplay = capoDisplay + " " + transposeDisplay;
+  const fixedTab = [capoAndTranspositionDisplay, ...trimmedTab];
+  return fixedTab;
 }
 
 interface TabDisplayProps {

--- a/frontend/src/components/transposer.tsx
+++ b/frontend/src/components/transposer.tsx
@@ -1,0 +1,83 @@
+const sharpToneArr = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+];
+
+const flatToneArr = [
+  "C",
+  "Db",
+  "D",
+  "Eb",
+  "E",
+  "F",
+  "Gb",
+  "G",
+  "Ab",
+  "A",
+  "Bb",
+  "B",
+];
+
+function getToneDetails(chordString) {
+  const chord =
+    chordString.substring(0, 1).toUpperCase() + chordString.substring(1, 2);
+  let hasAccidental = true;
+  let chordIndex = sharpToneArr.indexOf(chord);
+
+  if (chordIndex === -1) {
+    chordIndex = flatToneArr.indexOf(chord);
+  }
+  if (chordIndex === -1) {
+    hasAccidental = false;
+  }
+  const shortChord = chord.substring(0, 1);
+  if (chordIndex === -1) {
+    chordIndex = flatToneArr.indexOf(shortChord);
+  }
+  if (chordIndex === -1) {
+    chordIndex = sharpToneArr.indexOf(shortChord);
+  }
+  return [chordIndex, hasAccidental];
+}
+
+function transposer(chords, steps, usesSharps) {
+  const splitChordsArray = chords.split("[/ch]").reduce((acc, cur) => {
+    return [...acc, ...cur.split("[ch]")];
+  }, []);
+  return splitChordsArray
+    .map((elem) => {
+      if (elem.replaceAll(" ", "") === "") {
+        return elem;
+      } else {
+        const [chordIndex, hasAccidental] = getToneDetails(elem);
+        if (chordIndex === -1) {
+          return elem;
+        } else {
+          const absoluteSteps = steps + 12;
+          const startRestOfChord = hasAccidental ? 2 : 1;
+          const sharpToneArrayReturn =
+            sharpToneArr[(chordIndex + absoluteSteps) % 12] +
+            elem.substring(startRestOfChord, elem.length);
+          const flatToneArrayReturn =
+            flatToneArr[(chordIndex + absoluteSteps) % 12] +
+            elem.substring(startRestOfChord, elem.length);
+          const toneArrayToReturn = usesSharps
+            ? sharpToneArrayReturn
+            : flatToneArrayReturn;
+          return toneArrayToReturn;
+        }
+      }
+    })
+    .join("");
+}
+export default transposer;


### PR DESCRIPTION
Adds use of #, -, and + to transpose songs on the fly. Note: currently does not alter value of capo or allow toggling of capo visibility.