### PR TITLE
Rejoin active songbook alert on home, plus misc frontend tidying

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -11,8 +11,8 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  ApplicationState,
   AppStateToTimerMap,
+  ApplicationState,
   LINES_PER_COLUMN,
   Songbook,
 } from "../models";
@@ -26,11 +26,11 @@ import {
   useOutlet,
   useParams,
 } from "react-router-dom";
+import { countTabColumns } from "../helpers/tab";
 import { nextSongbookSong } from "../services/songs";
+import ColumnMap from "./ColumnMap";
 import HamburgerMenu from "./HamburgerMenu";
 import Timer from "./Timer";
-import { countTabColumns } from "../helpers/tab";
-import ColumnMap from "./ColumnMap";
 
 interface NavBarProps {
   asyncSongbook: UseAsyncReturn<AxiosResponse<Songbook, any>, never[]>;
@@ -62,7 +62,7 @@ export default function NavBar({
   // state for length of countdown timer in seconds
   const navigate = useNavigate();
   const [countdownTimerInSeconds, setCountdownTimerInSeconds] = useState(
-    AppStateToTimerMap[applicationState]
+    AppStateToTimerMap[applicationState],
   );
   const [isTimerVisible, setIsTimerVisible] = useBoolean(false);
   const [isSmallerThan900] = useMediaQuery("(max-width: 900px)");
@@ -77,12 +77,12 @@ export default function NavBar({
     () =>
       countTabColumns(
         asyncSongbook.result?.data?.current_song_entry?.song?.content,
-        LINES_PER_COLUMN
+        LINES_PER_COLUMN,
       ),
     [
       asyncSongbook.result?.data?.current_song_entry?.song?.content,
       LINES_PER_COLUMN,
-    ]
+    ],
   );
 
   const timerControls = {
@@ -181,18 +181,22 @@ export default function NavBar({
               >
                 <Link
                   fontWeight="bold"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   href={currentSongbook.current_song_entry?.song.url}
                 >
                   "{currentSongbook.current_song_entry?.song.title}" by{" "}
                   {currentSongbook.current_song_entry?.song.artist}
                 </Link>{" "}
               </Text>
-              <Text align="center" fontSize="1.5xl">
-                {currentSongbook.title}
-                {" - "} ({"song "}
-                {currentSongbook.current_song_position} of{" "}
-                {currentSongbook.total_songs})
-              </Text>
+              <RouterLink to={`/live/${currentSongbook.session_key}/list`}>
+                <Text align="center" fontSize="1.5xl">
+                  {currentSongbook.title}
+                  {" - "} ({"song "}
+                  {currentSongbook.current_song_position} of{" "}
+                  {currentSongbook.total_songs})
+                </Text>
+              </RouterLink>
             </>
           ) : (
             <Skeleton

--- a/frontend/src/components/SongbookIndexTable.tsx
+++ b/frontend/src/components/SongbookIndexTable.tsx
@@ -21,18 +21,6 @@ export default function SongbookIndexTable({ songbooks }) {
           <UnorderedList>
             {songbooks &&
               songbooks
-                .filter(({ is_noodle_mode }) => !is_noodle_mode)
-                .map(({ title, session_key }) => (
-                  <ListItem key={session_key}>
-                    <Link to={`/live/${session_key}/`}>{title}</Link>
-                  </ListItem>
-                ))}
-          </UnorderedList>
-        </TabPanel>
-        <TabPanel>
-          <UnorderedList>
-            {songbooks &&
-              songbooks
                 .filter(({ is_noodle_mode }) => is_noodle_mode)
                 .map(({ title, session_key }) => (
                   <ListItem key={session_key}>

--- a/frontend/src/components/SongbookIndexTable.tsx
+++ b/frontend/src/components/SongbookIndexTable.tsx
@@ -13,8 +13,8 @@ export default function SongbookIndexTable({ songbooks }) {
   return (
     <Tabs isFitted variant="enclosed-colored" width="26rem">
       <TabList>
-        <Tab>Power Hour</Tab>
-        <Tab>Noodle Mode</Tab>
+        <Tab>Songbooks</Tab>
+        <Tab>Power Hours</Tab>
       </TabList>
       <TabPanels>
         <TabPanel>
@@ -36,6 +36,18 @@ export default function SongbookIndexTable({ songbooks }) {
                 .filter(({ is_noodle_mode }) => is_noodle_mode)
                 .map(({ title, session_key }) => (
                   <ListItem key={session_key}>
+                    <Link to={`/live/${session_key}/`}>{title}</Link>
+                  </ListItem>
+                ))}
+          </UnorderedList>
+        </TabPanel>
+        <TabPanel>
+          <UnorderedList>
+            {songbooks &&
+              songbooks
+                .filter(({ is_noodle_mode }) => !is_noodle_mode)
+                .map(({ title, session_key }) => (
+                  <ListItem>
                     <Link to={`/live/${session_key}/`}>{title}</Link>
                   </ListItem>
                 ))}

--- a/frontend/src/components/SongbookIndexTable.tsx
+++ b/frontend/src/components/SongbookIndexTable.tsx
@@ -47,7 +47,7 @@ export default function SongbookIndexTable({ songbooks }) {
               songbooks
                 .filter(({ is_noodle_mode }) => !is_noodle_mode)
                 .map(({ title, session_key }) => (
-                  <ListItem>
+                  <ListItem key={session_key}>
                     <Link to={`/live/${session_key}/`}>{title}</Link>
                   </ListItem>
                 ))}

--- a/frontend/src/components/TabDisplay.tsx
+++ b/frontend/src/components/TabDisplay.tsx
@@ -1,8 +1,8 @@
 import { Flex, Text, useColorModeValue, useMediaQuery } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
-import transposer from "./transposer";
 import { formatTab, splitTabIntoColumns } from "../helpers/tab";
 import { LINES_PER_COLUMN } from "../models";
+import transposer from "./transposer";
 
 interface TabDisplayProps {
   tab: string | false | undefined;
@@ -37,7 +37,7 @@ export default function TabDisplay({
         setUsesSharps(!usesSharps);
       }
     },
-    [handleTransposeChange, usesSharps, setUsesSharps]
+    [handleTransposeChange, usesSharps, setUsesSharps],
   );
 
   useEffect(() => {
@@ -110,8 +110,9 @@ function TabWithChords({
       {tabToDisplay &&
         tabToDisplay
           // .slice(firstColDispIndex, firstColDispIndex + columnsToDisplay)
-          .map((column) => (
+          .map((column, idx) => (
             <Text
+              key={idx}
               as="pre"
               style={{ fontSize: "1rem", fontFamily: "Ubuntu Mono" }}
               w={`${100 / columnsToDisplay}%`}

--- a/frontend/src/components/WelcomePage.tsx
+++ b/frontend/src/components/WelcomePage.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertIcon, Button, Center, Flex, Text } from "@chakra-ui/react";
+import { Alert, Button, Center, Flex, Text } from "@chakra-ui/react";
 import { useAsync } from "react-async-hook";
 import { Link, useNavigate } from "react-router-dom";
 import { getAllSongbooks, getUserDetails } from "../services/songs";
@@ -9,9 +9,13 @@ export default function WelcomePage() {
   const songbooks = asyncSongbooks.result?.data.results;
   const asyncUser = useAsync(async () => getUserDetails(), []);
   const user = asyncUser.result && asyncUser.result.data;
+  const liveSongbooks = songbooks?.filter(
+    (songbook) => songbook.is_noodle_mode === false,
+  );
   const navigate = useNavigate();
   return (
     <>
+      <pre>{JSON.stringify(liveSongbooks, null, 2)}</pre>
       <Flex justifyContent="center">
         <Flex alignItems="center" direction="column">
           <Text
@@ -24,16 +28,21 @@ export default function WelcomePage() {
             livepowerhour.com
           </Text>
           {user && <Center>Welcome, {user?.first_name}!</Center>}
-          <Alert
-            status="warning"
-            margin="1rem"
-            justifyContent="center"
-            cursor="pointer"
-            onClick={() => navigate("/live/sams-test")}
-          >
-            <AlertIcon />
-            Click here to return to your active power hour!
-          </Alert>
+          {liveSongbooks &&
+            liveSongbooks.length &&
+            liveSongbooks.map((songbook) => (
+              <Alert
+                margin="1rem"
+                status="warning"
+                textAlign="center"
+                width="28rem"
+                padding="2rem"
+                cursor="pointer"
+                onClick={() => navigate("/live/sams-test")}
+              >
+                Return to your recent power hour: {songbook.title}
+              </Alert>
+            ))}
           <Text
             mb="1rem"
             fontSize="2rem"

--- a/frontend/src/components/WelcomePage.tsx
+++ b/frontend/src/components/WelcomePage.tsx
@@ -1,6 +1,6 @@
-import { Box, Button, Center, Flex, Text } from "@chakra-ui/react";
+import { Alert, AlertIcon, Button, Center, Flex, Text } from "@chakra-ui/react";
 import { useAsync } from "react-async-hook";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { getAllSongbooks, getUserDetails } from "../services/songs";
 import SongbookIndexTable from "./SongbookIndexTable";
 
@@ -9,28 +9,31 @@ export default function WelcomePage() {
   const songbooks = asyncSongbooks.result?.data.results;
   const asyncUser = useAsync(async () => getUserDetails(), []);
   const user = asyncUser.result && asyncUser.result.data;
+  const navigate = useNavigate();
   return (
-    <Box>
-      <Text
-        fontSize="3rem"
-        align="center"
-        fontFamily="Ubuntu Mono"
-        color="blue.600"
-        pt="1rem"
-        pb="1rem"
-      >
-        livepowerhour.com
-      </Text>
-      {user && <Center>Welcome, {user?.first_name}!</Center>}
-      <Center>
-        <Link to={`/live/profile/`}>
-          <Button colorScheme="blue" m="1rem">
-            Your Profile
-          </Button>
-        </Link>
-      </Center>
+    <>
       <Flex justifyContent="center">
         <Flex alignItems="center" direction="column">
+          <Text
+            fontSize="3rem"
+            fontFamily="Ubuntu Mono"
+            color="blue.600"
+            pt="2rem"
+            pb="2rem"
+          >
+            livepowerhour.com
+          </Text>
+          {user && <Center>Welcome, {user?.first_name}!</Center>}
+          <Alert
+            status="warning"
+            margin="1rem"
+            justifyContent="center"
+            cursor="pointer"
+            onClick={() => navigate("/live/sams-test")}
+          >
+            <AlertIcon />
+            Click here to return to your active power hour!
+          </Alert>
           <Text
             mb="1rem"
             fontSize="2rem"
@@ -46,6 +49,6 @@ export default function WelcomePage() {
           </Link>
         </Flex>
       </Flex>
-    </Box>
+    </>
   );
 }

--- a/frontend/src/components/WelcomePage.tsx
+++ b/frontend/src/components/WelcomePage.tsx
@@ -16,13 +16,17 @@ export default function WelcomePage() {
   const songbooks = asyncSongbooks.result?.data.results;
   const asyncUser = useAsync(async () => getUserDetails(), []);
   const user = asyncUser.result && asyncUser.result.data;
-  const liveSongbooks = songbooks?.filter(
-    (songbook) => songbook.is_noodle_mode === false,
-  );
+  const activePowerHours = songbooks?.filter((songbook) => {
+    const currentTime = new Date(Date.now()).getTime();
+    const songbookTime = new Date(songbook["current_song_timestamp"]).getTime();
+    return (
+      songbook.is_noodle_mode === false &&
+      (currentTime - songbookTime) / (1000 * 60 * 60) < 8
+    );
+  });
   const navigate = useNavigate();
   return (
     <>
-      {/* <pre>{JSON.stringify(liveSongbooks, null, 2)}</pre> */}
       <Flex justifyContent="center">
         <Flex alignItems="center" direction="column">
           <Text
@@ -40,19 +44,19 @@ export default function WelcomePage() {
               Profile
             </Button>
           </Link>
-          {liveSongbooks &&
-            liveSongbooks.length &&
-            liveSongbooks.map((songbook) => (
+          {activePowerHours &&
+            activePowerHours.map((songbook) => (
               <Alert
+                key={songbook.session_key}
                 margin="1rem"
                 status="warning"
                 textAlign="center"
                 width="28rem"
                 padding="2rem"
                 cursor="pointer"
-                onClick={() => navigate("/live/sams-test")}
+                onClick={() => navigate(`/live/${songbook.session_key}`)}
               >
-                <AlertIcon />
+                <AlertIcon key={songbook.id} />
                 Return to power hour: {songbook.title}
               </Alert>
             ))}
@@ -67,7 +71,9 @@ export default function WelcomePage() {
           </Text>
           <SongbookIndexTable songbooks={songbooks} />
           <Link to={`/live/createsongbook/`}>
-            <Button colorScheme="blue">Create a New Songbook</Button>
+            <Button margin="2rem" colorScheme="blue">
+              Create a New Songbook
+            </Button>
           </Link>
         </Flex>
       </Flex>

--- a/frontend/src/components/WelcomePage.tsx
+++ b/frontend/src/components/WelcomePage.tsx
@@ -1,4 +1,11 @@
-import { Alert, Button, Center, Flex, Text } from "@chakra-ui/react";
+import {
+  Alert,
+  AlertIcon,
+  Button,
+  Flex,
+  Heading,
+  Text,
+} from "@chakra-ui/react";
 import { useAsync } from "react-async-hook";
 import { Link, useNavigate } from "react-router-dom";
 import { getAllSongbooks, getUserDetails } from "../services/songs";
@@ -15,7 +22,7 @@ export default function WelcomePage() {
   const navigate = useNavigate();
   return (
     <>
-      <pre>{JSON.stringify(liveSongbooks, null, 2)}</pre>
+      {/* <pre>{JSON.stringify(liveSongbooks, null, 2)}</pre> */}
       <Flex justifyContent="center">
         <Flex alignItems="center" direction="column">
           <Text
@@ -27,7 +34,12 @@ export default function WelcomePage() {
           >
             livepowerhour.com
           </Text>
-          {user && <Center>Welcome, {user?.first_name}!</Center>}
+          {user && <Heading size="md">Welcome, {user?.first_name}!</Heading>}
+          <Link to={`/live/profile/`}>
+            <Button margin="2rem" colorScheme="blue">
+              Profile
+            </Button>
+          </Link>
           {liveSongbooks &&
             liveSongbooks.length &&
             liveSongbooks.map((songbook) => (
@@ -40,7 +52,8 @@ export default function WelcomePage() {
                 cursor="pointer"
                 onClick={() => navigate("/live/sams-test")}
               >
-                Return to your recent power hour: {songbook.title}
+                <AlertIcon />
+                Return to power hour: {songbook.title}
               </Alert>
             ))}
           <Text


### PR DESCRIPTION
1. For the "rejoin active songbook" alert on home, in lieu of date_created on songbooks, I'm currently filtering on current_song_timestamp which we are already serving. Seems like date_created would be optimal for live songbooks and date modified for noodle mode. 
2. I also cleaned up some warnings related to keys on maps and added two link changes to current song view.
3. Lastly, I swapped the sequence of all songbooks tabs so that noodle mode books are the first tab instead of the second.

![Screen Shot 2023-05-30 at 12 24 37 PM](https://github.com/samdatkins/sing-along/assets/52581258/dc5fcd2e-bda9-4127-a5c3-154040dfcfbb)