### PR TITLE
redesign of song request drawer

### DIFF
--- a/frontend/src/components/AddSongDrawer.tsx
+++ b/frontend/src/components/AddSongDrawer.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertDescription,
   AlertIcon,
+  Box,
   Button,
   Drawer,
   DrawerBody,
@@ -10,13 +11,14 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerOverlay,
-  SlideFade,
   Flex,
+  SlideFade,
   useDisclosure,
 } from "@chakra-ui/react";
-import { useContext, useState } from "react";
+import React, { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import SongbookContext from "../contexts/SongbookContext";
+import useWindowDimensions from "../helpers/useWindowDimensions";
 import { ChakraAlertStatus } from "../models";
 import { addSongToSongbook, deleteSongbookSong } from "../services/songs";
 import SongSearchAutocomplete from "./SongSearchAutocomplete";
@@ -32,10 +34,16 @@ export default function AddSongDrawer() {
   const [undoSongEntryID, setUndoSongEntryID] = useState<number | undefined>();
   const songbook = useContext(SongbookContext);
 
+  const songRequestInput = React.useRef(null);
+
+  const { height: windowHeight } = useWindowDimensions();
+
   return (
     <>
       <Drawer
         isOpen={isDrawerOpen}
+        initialFocusRef={songRequestInput}
+        placement="bottom"
         onClose={() => {
           onDrawerClose();
           // Finish animation before navigating
@@ -49,57 +57,60 @@ export default function AddSongDrawer() {
           <DrawerHeader>Request a song for "{songbook?.title}"</DrawerHeader>
 
           <DrawerBody>
-            <SongSearchAutocomplete
-              onSubmit={async (song) => {
-                setAlertText("");
-                setAlertStatus(undefined);
+            <Box height={windowHeight * 0.8}>
+              <SongSearchAutocomplete
+                songRequestInput={songRequestInput}
+                onSubmit={async (song) => {
+                  setAlertText("");
+                  setAlertStatus(undefined);
 
-                const addSongResult = await addSongToSongbook(
-                  song,
-                  songbook?.id
-                );
-                if (typeof addSongResult === "string") {
-                  const isWarning = addSongResult.includes("already");
-                  setAlertStatus(isWarning ? "warning" : "error");
-                  setAlertText(addSongResult);
-                  if (isWarning) {
+                  const addSongResult = await addSongToSongbook(
+                    song,
+                    songbook?.id
+                  );
+                  if (typeof addSongResult === "string") {
+                    const isWarning = addSongResult.includes("already");
+                    setAlertStatus(isWarning ? "warning" : "error");
+                    setAlertText(addSongResult);
+                    if (isWarning) {
+                      return true;
+                    }
+                    return false;
+                  } else {
+                    setUndoSongEntryID(addSongResult.data.id);
+                    setAlertStatus("success");
+                    setAlertText(
+                      `Successfully added "${song.title}" by ${song.artist}.`
+                    );
                     return true;
                   }
-                  return false;
-                } else {
-                  setUndoSongEntryID(addSongResult.data.id);
-                  setAlertStatus("success");
-                  setAlertText(
-                    `Successfully added "${song.title}" by ${song.artist}.`
-                  );
-                  return true;
-                }
-              }}
-            />
+                }}
+              />
 
-            <SlideFade in={!!alertText} style={{ zIndex: 10 }} offsetY="20px">
-              <Alert status={alertStatus} py="2rem" rounded="md" mt="3rem">
-                <Flex direction="column">
-                  <Flex direction="row" alignItems="center">
-                    <AlertIcon />
-                    <AlertDescription>{alertText}</AlertDescription>
+              <SlideFade in={!!alertText} style={{ zIndex: 10 }} offsetY="20px">
+                <Alert status={alertStatus} py="2rem" rounded="md" mt="3rem">
+                  <Flex direction="column">
+                    <Flex direction="row" alignItems="center">
+                      <AlertIcon />
+                      <AlertDescription>{alertText}</AlertDescription>
+                    </Flex>
+                    {undoSongEntryID !== undefined && (
+                      <Button
+                        mt="1rem"
+                        onClick={() => {
+                          deleteSongbookSong(undoSongEntryID);
+                          setUndoSongEntryID(undefined);
+                          setAlertText("");
+                          setAlertStatus(undefined);
+                        }}
+                      >
+                        Undo
+                      </Button>
+                    )}
                   </Flex>
-                  {undoSongEntryID !== undefined && (
-                    <Button
-                      mt="1rem"
-                      onClick={() => {
-                        deleteSongbookSong(undoSongEntryID);
-                        setUndoSongEntryID(undefined);
-                        setAlertText("");
-                        setAlertStatus(undefined);
-                      }}
-                    >
-                      Undo
-                    </Button>
-                  )}
-                </Flex>
-              </Alert>
-            </SlideFade>
+                </Alert>
+              </SlideFade>
+            </Box>
           </DrawerBody>
 
           <DrawerFooter></DrawerFooter>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -161,6 +161,12 @@ export default function NavBar({
     cursor: "pointer",
   };
 
+  const addIconStyle = {
+    opacity: "65%",
+    margin: "0px",
+    padding: "0px",
+  };
+
   const handleHeartClick = async () => {
     if (!asyncSongbook?.result?.data) {
       return;
@@ -175,7 +181,10 @@ export default function NavBar({
   return (
     <Flex flexDir="row" justifyContent="space-between">
       {/* LEFT COLUMN */}
-      <Flex justifyContent="space-between" width={!isMobileDevice ? "33%" : ""}>
+      <Flex
+        justifyContent="space-between"
+        width={!isMobileDevice ? "33%" : "12%"}
+      >
         <Flex paddingRight="1rem">
           <HamburgerMenu
             isMobileDevice={isMobileDevice}
@@ -219,7 +228,7 @@ export default function NavBar({
       {/* MIDDLE COLUMN */}
       <Flex
         alignItems="center"
-        width={!isMobileDevice ? "34%" : ""}
+        width={!isMobileDevice ? "34%" : "78%"}
         justifyContent="center"
       >
         <Flex direction="column">
@@ -263,7 +272,10 @@ export default function NavBar({
         </Flex>
       </Flex>
       {/* RIGHT COLUMN */}
-      <Flex width={!isMobileDevice ? "33%" : ""} justifyContent="space-between">
+      <Flex
+        width={!isMobileDevice ? "33%" : "10%"}
+        justifyContent="space-between"
+      >
         <Flex></Flex>
         <Flex>
           <Flex justifyContent="center">
@@ -307,29 +319,34 @@ export default function NavBar({
             </>
           )
         ) : (
-          <Flex w="34%" justifyContent="end">
-            <Button colorScheme="blue" as={RouterLink} to={"add-song"}>
-              <AddIcon />
-            </Button>
-          </Flex>
+          <Flex justifyContent="end"> </Flex>
         )}
         {addSongDrawerOutlet}
       </Flex>
-      {/* LIKE ICON */}
+
       {(!asyncSongbook?.result?.data?.is_songbook_owner || isMobileDevice) && (
         <Portal>
-          <Flex
-            position="fixed"
-            right="20px"
-            bottom="20px"
-            margin="0"
-            padding="0"
-          >
+          <Flex position="fixed" right="10px" top="10px">
             {isLiked ? (
               <BsSuitHeartFill {...heartIconStyle} onClick={handleHeartClick} />
             ) : (
               <BsSuitHeart {...heartIconStyle} onClick={handleHeartClick} />
             )}
+          </Flex>
+        </Portal>
+      )}
+
+      {(!asyncSongbook?.result?.data?.is_songbook_owner || isMobileDevice) && (
+        <Portal>
+          <Flex position="fixed" right="10px" bottom="10px">
+            <Button
+              as={RouterLink}
+              to={"add-song"}
+              colorScheme="blue"
+              {...addIconStyle}
+            >
+              <AddIcon />
+            </Button>
           </Flex>
         </Portal>
       )}

--- a/frontend/src/components/SongSearchAutocomplete.tsx
+++ b/frontend/src/components/SongSearchAutocomplete.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   useBoolean,
 } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAsync } from "react-async-hook";
 import { useDebounce } from "usehooks-ts";
 import { Song } from "../models";
@@ -16,10 +16,12 @@ import { searchForSong } from "../services/songs";
 
 type SongSearchAutocompleteProps = {
   onSubmit: (song: Song) => Promise<boolean>;
+  songRequestInput: React.MutableRefObject<null>;
 };
 
 export default function SongSearchAutocomplete({
   onSubmit,
+  songRequestInput,
 }: SongSearchAutocompleteProps) {
   const [searchText, setSearchText] = useState("");
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
@@ -68,6 +70,7 @@ export default function SongSearchAutocomplete({
       <InputGroup size="md">
         <Input
           placeholder="Lynyrd Skynyrd - Free Bird"
+          ref={songRequestInput}
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
           disabled={isSubmitting}

--- a/frontend/src/helpers/useWindowDimensions.ts
+++ b/frontend/src/helpers/useWindowDimensions.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height
+  };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}


### PR DESCRIPTION
A few styling changes for mobile users during singalongs:

- AddSongDrawer now comes in from the bottom and leaves the top 20% of the page revealed for greater feature discoverability.
- The positions of "like song" and "request song" buttons are swapped; "like" is now top-right, alongside the title of the song.
- "Like" and "add" buttons are now fixed in their respective corners for continuous access.