### PR TITLE
Update poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:18 AS frontend
+FROM node:21 AS frontend
 RUN mkdir /code
 WORKDIR /code
 
@@ -7,7 +7,9 @@ COPY frontend/ frontend-build/
 WORKDIR /code/frontend-build/
 RUN yarn install && GENERATE_SOURCEMAP=false yarn build
 
-FROM python:3.10-slim-bullseye
+# using 3.11 for now because 3.12 breaks things, could fix this but it would slow down
+# deploys: https://stackoverflow.com/questions/77364550/attributeerror-module-pkgutil-has-no-attribute-impimporter-did-you-mean
+FROM python:3.11-slim-bullseye
 ARG YOUR_ENV
 
 ENV YOUR_ENV=${YOUR_ENV}
@@ -15,7 +17,7 @@ ENV PYTHONUNBUFFERED=1
 
 # System deps:
 RUN apt-get update && apt-get install -y gcc musl-dev python3-dev libffi-dev cargo rustc postgresql-client
-RUN pip install "poetry==1.2.2"
+RUN pip install "poetry==1.7.1"
 
 # Copy only requirements to cache them in docker layer
 WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Installation
 
 - Backend
-  - Ensure you're running python 3.9 or 3.10 (`python3 --version`)
-    - If not, install and use python 3.9 or 3.10 using `pyenv`
+  - Ensure you're running python 3.9 - 3.11 (`python3 --version`)
+    - If not, install and use python 3.11 using `pyenv`
   - Install [Docker Desktop](https://www.docker.com/products/docker-desktop)
   - Install pipx
     - `brew install pipx`


### PR DESCRIPTION
Deployments keep failing on digital ocean unless I force a rebuild. My suspicion is that this is a bug with poetry or pip, but this is really just a guess.

Also looked into the issue with python 3.12 - it's fixable but it would require some manual intervention that I'm not interested in a) forcing devs to do to their local environments and b) I don't want to apply to deployments, thus slowing them down.