### PR TITLE
fix: Docker entrypoint psql pager hang and production guard

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,3 +1,7 @@
+# development | production — must match on the host (Appliku: set both or DJANGO_ENV).
+DJANGO_ENV=development
+YOUR_ENV=development
+
 TAB_SEARCH_URL=
 TAB_ARTIST_SONGS_INDEX=
 TAB_BAND_INDEX=

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
+# psql uses $PAGER (often `less`) for multi-line output; that blocks with "(END)" until a key is
+# pressed, so the wait loop never completes and gunicorn never starts. Force no pager.
+export PAGER=cat
+export PSQL_PAGER=cat
+
 until psql "${DATABASE_URL}" -c '\l'; do
   echo >&2 "postgres is unavailable - sleeping"
   sleep 1
 done
 
-if [ "${YOUR_ENV}" == "production" ]; then
-  ./scripts/docker-entrypoint.prod.sh
+# Appliku and some hosts set DJANGO_ENV=production but not YOUR_ENV; honor either.
+if [ "${YOUR_ENV}" == "production" ] || [ "${DJANGO_ENV}" == "production" ]; then
+  exec ./scripts/docker-entrypoint.prod.sh
 else
-  ./scripts/docker-entrypoint.dev.sh
+  exec ./scripts/docker-entrypoint.dev.sh
 fi

--- a/sing_along/settings.py
+++ b/sing_along/settings.py
@@ -131,7 +131,7 @@ WSGI_APPLICATION = "sing_along.wsgi.application"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 
-if len(sys.argv) > 0 and sys.argv[1] != "collectstatic":
+if len(sys.argv) <= 1 or sys.argv[1] != "collectstatic":
     if os.getenv("DATABASE_URL", None) is None:
         raise Exception("DATABASE_URL environment variable not defined")
     DATABASES = {


### PR DESCRIPTION
This PR fixes the web container never reaching gunicorn when `psql` pages multi-line output through `less`, which blocks on `(END)` until a keypress.

Also:
- Treat `DJANGO_ENV=production` like `YOUR_ENV` for choosing the prod entrypoint, and `exec` the prod/dev scripts.
- Document `YOUR_ENV` / `DJANGO_ENV` in `.env-sample`.
- Correct the `DATABASE_URL` / `collectstatic` guard in `settings.py` so `sys.argv[1]` is not accessed when no subcommand is present.

**How to verify locally:** `docker compose run --rm -e YOUR_ENV=production -e DJANGO_ENV=production web ./scripts/docker-entrypoint.sh` should proceed past the Postgres wait to collectstatic/migrate/gunicorn without hanging.

Made with [Cursor](https://cursor.com)