### PR TITLE
fix: keep preview when user navigates during commit

### DIFF
--- a/frontend/src/components/CurrentSongView.tsx
+++ b/frontend/src/components/CurrentSongView.tsx
@@ -126,11 +126,14 @@ function CurrentSongView({ asyncUser }: CurrentSongViewProps) {
     const serverPos = songbook?.current_song_position;
     if (serverPos === committed) {
       committedPositionRef.current = null;
-      setPreviewPosition(null);
       setIsCommitting(false);
-      setFirstColDispIndex(0);
+      // Only clear preview if the user hasn't navigated to a new position during the commit
+      if (previewPosition === null || previewPosition === committed) {
+        setPreviewPosition(null);
+        setFirstColDispIndex(0);
+      }
     }
-  }, [songbook?.current_song_position, asyncSongbook.result]);
+  }, [songbook?.current_song_position, asyncSongbook.result, previewPosition]);
 
   // Debounce: commit preview after PREVIEW_DEBOUNCE_MS of inactivity
   useEffect(() => {


### PR DESCRIPTION
## Problem

While a preview commit is in flight (`isCommitting`), the debounce effect does not schedule a new commit. When the server data landed, we unconditionally cleared `previewPosition` to `null`. If the user had navigated to another song during the commit, that final preview was wiped and never committed.

## Fix

In the data-landed effect, only call `setPreviewPosition(null)` (and reset column index) when `previewPosition` is still `null` or still equals the committed position. Otherwise leave the new preview in place; `setIsCommitting(false)` allows the debounce to run for the new position.

Made with [Cursor](https://cursor.com)